### PR TITLE
Verbose output explaining the SubER score

### DIFF
--- a/suber/metrics/suber_statistics.py
+++ b/suber/metrics/suber_statistics.py
@@ -1,0 +1,82 @@
+from typing import Dict, List, Any
+from collections import OrderedDict
+
+from suber.data_types import Word
+from suber.constants import END_OF_LINE_SYMBOL, END_OF_BLOCK_SYMBOL
+
+
+class SubERStatisticsCollector:
+    """
+    Collects number of different SubER edit operations necessary to turn the reference into the hypothesis.
+    (The TER code and paper uses the hypothesis to reference direction, but calling a word occurring only in the
+    hypothesis an insertion and a word missing in the hypothesis a deletion seems to be far more common.)
+    """
+
+    def __init__(self):
+        self._num_reference_words = 0
+        self._num_reference_breaks = 0
+        self._num_shifts = 0
+        self._num_word_deletions = 0
+        self._num_break_deletions = 0
+        self._num_word_insertions = 0
+        self._num_break_insertions = 0
+        self._num_word_substitutions = 0
+        self._num_break_substitutions = 0
+
+    def add_data(self, trace: str, words_ref: List[Word], words_hyp_shifted: List[Word], num_shifts: int):
+        """
+        Called inside lib_ter.translation_edit_rate(). 'trace' contains characters 'i', 'd', 's' and ' ' representing
+        different edit operations.
+        """
+        reference_position = -1
+        hypothesis_position = -1
+
+        for edit_operation in trace:
+            if edit_operation != "i":
+                reference_position += 1
+
+            if edit_operation != "d":
+                hypothesis_position += 1
+
+            if edit_operation == "i":
+                if words_hyp_shifted[hypothesis_position].string in [END_OF_LINE_SYMBOL, END_OF_BLOCK_SYMBOL]:
+                    self._num_break_insertions += 1
+                else:
+                    self._num_word_insertions += 1
+            else:
+                is_break_edit = words_ref[reference_position].string in [END_OF_LINE_SYMBOL, END_OF_BLOCK_SYMBOL]
+
+                if is_break_edit:
+                    self._num_reference_breaks += 1
+                else:
+                    self._num_reference_words += 1
+
+                if edit_operation == "d":
+                    if is_break_edit:
+                        self._num_break_deletions += 1
+                    else:
+                        self._num_word_deletions += 1
+
+                elif edit_operation == "s":
+                    if is_break_edit:
+                        self._num_break_substitutions += 1
+                    else:
+                        self._num_word_substitutions += 1
+
+        assert reference_position == len(words_ref) - 1
+        assert hypothesis_position == len(words_hyp_shifted) - 1
+
+        self._num_shifts += num_shifts
+
+    def get_statistics(self) -> Dict[str, Any]:
+        return OrderedDict(
+            num_reference_words=self._num_reference_words,
+            num_reference_breaks=self._num_reference_breaks,
+            num_shifts=self._num_shifts,
+            num_word_deletions=self._num_word_deletions,
+            num_break_deletions=self._num_break_deletions,
+            num_word_insertions=self._num_word_insertions,
+            num_break_insertions=self._num_break_insertions,
+            num_word_substitutions=self._num_word_substitutions,
+            num_break_substitutions=self._num_break_substitutions,
+        )

--- a/tests/test_suber_metric.py
+++ b/tests/test_suber_metric.py
@@ -141,7 +141,7 @@ class SubERMetricTests(unittest.TestCase):
             2
             0:00:03.500 --> 0:00:04.000
             another one!"""
-        # (2 break deletions + 1 break substitution) / (7 words + 2 breaks)
+        # (2 break insertions + 1 break substitution) / (7 words + 2 breaks)
         self._run_test(hypothesis, self._reference2, expected_score=33.333)
 
     def test_split_into_three_with_one_shift(self):
@@ -158,7 +158,7 @@ class SubERMetricTests(unittest.TestCase):
             2
             0:00:03.500 --> 0:00:04.000
             And one!"""
-        # (1 shift + 2 break deletions) / (7 words + 2 breaks)
+        # (1 shift + 2 break insertions) / (7 words + 2 breaks)
         self._run_test(hypothesis, self._reference2, expected_score=33.333)
 
 

--- a/tests/test_suber_statistics.py
+++ b/tests/test_suber_statistics.py
@@ -1,0 +1,164 @@
+import unittest
+
+from typing import Dict, Any
+
+from suber.metrics.suber import calculate_SubER
+from suber.metrics.suber_statistics import SubERStatisticsCollector
+from .utilities import create_temporary_file_and_read_it
+
+
+class SubERStatisticsTests(unittest.TestCase):
+    """
+    Mostly copied from SubERMetricsTests, but now testing the statistics collection.
+    """
+
+    def setUp(self):
+        self._reference1 = """
+            1
+            0:00:01.000 --> 0:00:02.000
+            This is a subtitle."""
+
+        self._reference2 = """
+            1
+            0:00:01.000 --> 0:00:02.000
+            This is a subtitle.
+
+            2
+            0:00:03.000 --> 0:00:04.000
+            And another one!"""
+
+        self._statistics_template = {
+        }
+
+    def _run_test(self, hypothesis, reference, expected_statistics: Dict[str, Any]):
+        hypothesis_subtitles = create_temporary_file_and_read_it(hypothesis)
+        reference_subtitles = create_temporary_file_and_read_it(reference)
+
+        statistics_collector = SubERStatisticsCollector()
+
+        _ = calculate_SubER(
+            hypothesis_subtitles,
+            reference_subtitles,
+            statistics_collector=statistics_collector)
+
+        statistics = statistics_collector.get_statistics()
+
+        for key, value in expected_statistics.items():
+            self.assertIn(key, statistics)
+            self.assertEqual(value, statistics[key], msg=f"key: {key}")
+
+    def test_empty(self):
+        expected_statistics = {
+            "num_reference_words": 0,
+            "num_reference_breaks": 0,
+            "num_shifts": 0,
+            "num_word_deletions": 0,
+            "num_break_deletions": 0,
+            "num_word_insertions": 0,
+            "num_break_insertions": 0,
+            "num_word_substitutions": 0,
+            "num_break_substitutions": 0,
+        }
+
+        self._run_test(hypothesis="", reference="", expected_statistics=expected_statistics)
+
+    def test_split_subtitle_no_overlap(self):
+        hypothesis = """
+            1
+            0:00:00.000 --> 0:00:00.500
+            This is
+
+            2
+            0:00:02.500 --> 0:00:03.000
+            a subtitle."""
+
+        expected_statistics = {
+            "num_reference_words": 4,
+            "num_reference_breaks": 1,
+            "num_shifts": 0,
+            "num_word_deletions": 4,
+            "num_break_deletions": 1,
+            "num_word_insertions": 4,
+            "num_break_insertions": 2,
+            "num_word_substitutions": 0,
+            "num_break_substitutions": 0,
+        }
+
+        self._run_test(hypothesis, self._reference1, expected_statistics=expected_statistics)
+
+    def test_split_subtitle_one_overlap(self):
+        hypothesis = """
+            1
+            0:00:00.000 --> 0:00:00.500
+            This is
+
+            2
+            0:00:01.500 --> 0:00:02.000
+            a subtitle."""
+
+        expected_statistics = {
+            "num_reference_words": 4,
+            "num_reference_breaks": 1,
+            "num_shifts": 0,
+            "num_word_deletions": 2,
+            "num_break_deletions": 0,
+            "num_word_insertions": 2,
+            "num_break_insertions": 1,
+            "num_word_substitutions": 0,
+            "num_break_substitutions": 0,
+        }
+
+        self._run_test(hypothesis, self._reference1, expected_statistics=expected_statistics)
+
+    def test_merged_subtitle_with_shift_and_substitution(self):
+        hypothesis = """
+            1
+            0:00:01.000 --> 0:00:04.000
+            That is a another one! subtitle.
+            And"""
+
+        expected_statistics = {
+            "num_reference_words": 7,
+            "num_reference_breaks": 2,
+            "num_shifts": 1,
+            "num_word_deletions": 0,
+            "num_break_deletions": 0,
+            "num_word_insertions": 0,
+            "num_break_insertions": 0,
+            "num_word_substitutions": 1,
+            "num_break_substitutions": 1,
+        }
+        self._run_test(hypothesis, self._reference2, expected_statistics=expected_statistics)
+
+    def test_split_into_three_with_one_shift(self):
+        hypothesis = """
+            1
+            0:00:01.000 --> 0:00:01.500
+            This is a
+
+            2
+            0:00:01.500 --> 0:00:03.500
+            another
+            subtitle.
+
+            2
+            0:00:03.500 --> 0:00:04.000
+            And one!"""
+
+        expected_statistics = {
+            "num_reference_words": 7,
+            "num_reference_breaks": 2,
+            "num_shifts": 1,
+            "num_word_deletions": 0,
+            "num_break_deletions": 0,
+            "num_word_insertions": 0,
+            "num_break_insertions": 2,
+            "num_word_substitutions": 0,
+            "num_break_substitutions": 0,
+        }
+
+        self._run_test(hypothesis, self._reference2, expected_statistics=expected_statistics)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@sarapapi That's what I have so far for #3.

Setting `--suber-statistics` as a command line option would lead to an output like:
```
{
    "SubER": 46.435,
    "#info": {
        "SubER": {
            "num_reference_words": 5946,
            "num_shifts": 230,
            "num_deletions": 828,
            "num_insertions": 783,
            "num_substitutions": 920
        }
    }
}
```

Not so sure about the output format, maybe I'm overdoing this json format. But I think it's better than writing to a separate file or just printing those statistics to stderr. The idea of the extra nesting level is that maybe at some point we want additional outputs also for other metrics.

What could further be added here:

- Separating `num_deletions` into `num_word_deletions` and `num_break_deletions`, same for insertions and substitutions (substitution of break is "end of block" <-> "end of line"). This gives some additional insights, for example whether there is over-/under-segmentation in general. But it requires an alignment of the words before and after the TER shifts so we know the positions of breaks in the edit operation "trace". Doable though...
By the way, `num_word_shifts` / `num_break_shifts` does not really make sense because it's ambiguous: swapping a word and a subsequent break could either be word shift right or break shift left.
- Output of the full Levenshtein alignment, e.g. in the form of hypothesis + reference word lists and an alignment like `0-0 1-2 2-3` etc. This could be used to create visualizations like Figure 3 in [the paper](https://aclanthology.org/2022.iwslt-1.1.pdf) to see which words / breaks exactly are edited. Nice to have, but not so high priority for me at the moment I would say.