### PR TITLE
New metric "SubER-cased"; also use tokenizer for "WER-cased"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The SubER score is printed to stdout in json format. As SubER is an edit rate, l
 Make sure that there is no constant time offset between the timestamps in hypothesis and reference as this will lead to incorrect scores.
 Also, note that `<i>`, `<b>` and `<u>` formatting tags are ignored if present in the files. All other formatting must be removed from the files before scoring for accurate results.
 
+#### Punctuation and Case-Sensitivity
+The main SubER metric is computed on normalized text, which means case-insensitive and without taking punctuation into account, as we observe higher correlation with human judgements and post-edit effort in this setting. We provide an implementation of a case-sensitive variant which also uses a tokenizer to take punctuation into account as separate tokens which you can use "at your own risk" or to reassess our findings. For this, add `--metrics SubER-cased` to the command above. Please do not report results using this variant as "SubER" unless explicitly mentioning the punctuation-/case-sensitivity.
+
 ## Other Metrics
 The SubER tool supports computing the following other metrics directly on subtitle files:
 

--- a/suber/__main__.py
+++ b/suber/__main__.py
@@ -90,13 +90,14 @@ def main():
             metric = metric[len("t-"):]
             score_break_at_segment_end = True
 
-        elif metric != "SubER" and len(hypothesis_segments_to_use) != len(reference_segments):
+        elif not metric.startswith("SubER") and len(hypothesis_segments_to_use) != len(reference_segments):
             raise ValueError(f"Metric '{metric}' assumes same number of segments in hypothesis and reference, but got "
                              f"{len(hypothesis_segments)} hypothesis and {len(reference_segments)} "
                              f"reference segments.")
 
-        if metric == "SubER":
-            metric_score = calculate_SubER(hypothesis=hypothesis_segments_to_use, reference=reference_segments)
+        if metric.startswith("SubER"):
+            metric_score = calculate_SubER(
+                hypothesis=hypothesis_segments_to_use, reference=reference_segments, metric=metric)
 
         elif metric.startswith("WER"):
             metric_score = calculate_word_error_rate(
@@ -121,7 +122,7 @@ def main():
 def check_metrics(metrics):
     allowed_metrics = {
         # Our proposed metric:
-        "SubER",
+        "SubER", "SubER-cased",
         # Established ASR and MT metrics, requiring aligned hypothesis-references segments:
         "WER", "CER", "BLEU", "TER", "chrF",
         # Cased and punctuated variants of the above:

--- a/tests/test_jiwer_interface.py
+++ b/tests/test_jiwer_interface.py
@@ -38,8 +38,8 @@ class JiWERInterfaceTest(unittest.TestCase):
         wer_cased_score = calculate_word_error_rate(
             hypothesis=hypothesis_subtitles, reference=reference_subtitles, metric="WER-cased")
 
-        # 2 substitutions (casing and punctuation error) / 13 words
-        self.assertAlmostEqual(wer_cased_score, 15.385)
+        # 2 substitutions (casing and punctuation error) / 15 tokenized words
+        self.assertAlmostEqual(wer_cased_score, 13.333)
 
         wer_seg_score = calculate_word_error_rate(
             hypothesis=hypothesis_subtitles, reference=reference_subtitles, metric="WER-seg")

--- a/tests/test_suber_metric.py
+++ b/tests/test_suber_metric.py
@@ -162,6 +162,41 @@ class SubERMetricTests(unittest.TestCase):
         self._run_test(hypothesis, self._reference2, expected_score=33.333)
 
 
+class SubERCasedMetricTests(unittest.TestCase):
+    def test_SubER_cased(self):
+        reference = """
+            1
+            0:00:01.000 --> 0:00:02.000
+            This is a subtitle.
+
+            2
+            0:00:03.000 --> 0:00:04.000
+            And another one!"""
+
+        hypothesis = """
+            1
+            0:00:01.000 --> 0:00:01.500
+            This is a
+
+            2
+            0:00:01.500 --> 0:00:03.500
+            another
+            subtitle,
+
+            2
+            0:00:03.500 --> 0:00:04.000
+            and one!"""
+
+        hypothesis_subtitles = create_temporary_file_and_read_it(hypothesis)
+        reference_subtitles = create_temporary_file_and_read_it(reference)
+
+        SubER_score = calculate_SubER(hypothesis_subtitles, reference_subtitles, metric="SubER-cased")
+
+        # After tokenization there should be 9 reference words + 2 reference break tokens.
+        # 1 shift and 2 break deletions as above for SubER, plus 2 substitutions: "," -> "."; "and" -> "And"
+        self.assertAlmostEqual(SubER_score, 45.455)
+
+
 class SubERHelperFunctionTests(unittest.TestCase):
 
     def test_get_independent_parts_empty_input(self):


### PR DESCRIPTION
See #5 
Adds the metric "SubER-cased", which is a case- and punctuation sensitive variant of SubER. Tokenization is used to treat punctuation as separate tokens. Note that the analysis in our paper shows weaker correlation with human post-editing effort. However, this variant might be useful when punctuation and casing errors are considered to be of high importance.

I also added tokenization to "WER-cased" to be consistent with "SubER-cased", because it makes sense intuitively, and also because it shows a slightly higher correlation than what we reported for "WER + case/punct" in the paper. (The numbers in Table 1 row 2 become -0.685, -0.520, -0.504, -0.657.) I think no one relies on the exact behaviour of "WER-cased" yet and it's ok to make a breaking change.
