### PR TITLE
Evaluate subtitle timing quality via speech activity detection metrics of pyannote

### DIFF
--- a/suber/metrics/pyannote_interface.py
+++ b/suber/metrics/pyannote_interface.py
@@ -1,0 +1,34 @@
+from typing import List
+from suber.data_types import Subtitle
+
+from pyannote.core import Segment, Annotation
+from pyannote.metrics.detection import (
+    DetectionAccuracy,
+    DetectionPrecision,
+    DetectionRecall,
+    DetectionPrecisionRecallFMeasure,
+)
+
+
+def calculate_time_span_accuracy(hypothesis: List[Subtitle], reference: List[Subtitle], metric="time_span_accuracy"):
+
+    reference_timings = Annotation()
+    for subtitle in reference:
+        reference_timings[Segment(subtitle.start_time, subtitle.end_time)] = str(subtitle.index)
+
+    hypothesis_timings = Annotation()
+    for subtitle in hypothesis:
+        hypothesis_timings[Segment(subtitle.start_time, subtitle.end_time)] = str(subtitle.index)
+
+    if metric == "time_span_accuracy":
+        pyannote_metric = DetectionAccuracy()
+    elif metric == "time_span_precision":
+        pyannote_metric = DetectionPrecision()
+    elif metric == "time_span_recall":
+        pyannote_metric = DetectionRecall()
+    elif metric == "time_span_f1":
+        pyannote_metric = DetectionPrecisionRecallFMeasure()
+
+    score = pyannote_metric(reference_timings, hypothesis_timings)
+
+    return round(score, 3)

--- a/tests/test_pyannote_interface.py
+++ b/tests/test_pyannote_interface.py
@@ -1,0 +1,83 @@
+import unittest
+
+from suber.metrics.pyannote_interface import calculate_time_span_accuracy
+from .utilities import create_temporary_file_and_read_it
+
+
+class PyAnnoteInterfaceTest(unittest.TestCase):
+    def setUp(self):
+        reference = """
+            1
+            0:00:01.000 --> 0:00:02.000
+            This is a subtitle.
+
+            2
+            0:00:03.000 --> 0:00:04.000
+            And another one!"""
+
+        self._reference = create_temporary_file_and_read_it(reference)
+
+    def test_time_span_accuracy_empty(self):
+        for metric in ("time_span_accuracy", "time_span_precision", "time_span_recall", "time_span_recall"):
+            score = calculate_time_span_accuracy(hypothesis=[], reference=[], metric=metric)
+            self.assertAlmostEqual(score, 1.0)
+
+        accuracy = calculate_time_span_accuracy(hypothesis=[], reference=self._reference, metric="time_span_accuracy")
+        self.assertAlmostEqual(accuracy, 0.333)  # Total interval is from 1 to 4 seconds, 1 second gap is true negative.
+        precision = calculate_time_span_accuracy(hypothesis=[], reference=self._reference, metric="time_span_precision")
+        self.assertAlmostEqual(precision, 1.0)
+        recall = calculate_time_span_accuracy(hypothesis=[], reference=self._reference, metric="time_span_recall")
+        self.assertAlmostEqual(recall, 0.0)
+
+        accuracy = calculate_time_span_accuracy(hypothesis=self._reference, reference=[], metric="time_span_accuracy")
+        self.assertAlmostEqual(accuracy, 0.333)
+        precision = calculate_time_span_accuracy(hypothesis=self._reference, reference=[], metric="time_span_precision")
+        self.assertAlmostEqual(precision, 0.0)
+        recall = calculate_time_span_accuracy(hypothesis=self._reference, reference=[], metric="time_span_recall")
+        self.assertAlmostEqual(recall, 1.0)
+
+    def test_time_span_accuracy_perfect(self):
+        for metric in ("time_span_accuracy", "time_span_precision", "time_span_recall", "time_span_recall"):
+            score = calculate_time_span_accuracy(hypothesis=self._reference, reference=self._reference, metric=metric)
+            self.assertAlmostEqual(score, 1.0)
+
+    def test_time_span_accuracy_no_overlap(self):
+        hypothesis = """
+            1
+            0:00:02.000 --> 0:00:03.000
+            This is a subtitle.
+
+            2
+            0:00:04.000 --> 0:00:05.000
+            And another one!"""
+        hypothesis = create_temporary_file_and_read_it(hypothesis)
+
+        for metric in ("time_span_accuracy", "time_span_precision", "time_span_recall", "time_span_recall"):
+            score = calculate_time_span_accuracy(hypothesis=hypothesis, reference=self._reference, metric=metric)
+            self.assertAlmostEqual(score, 0.0)
+
+    def test_time_span_accuracy_some_overlap(self):
+        hypothesis = """
+            1
+            0:00:01.500 --> 0:00:02.500
+            The text doesn't matter.
+
+            2
+            0:00:03.200 --> 0:00:03.800
+            """
+        hypothesis = create_temporary_file_and_read_it(hypothesis)
+
+        accuracy = calculate_time_span_accuracy(
+            hypothesis=hypothesis, reference=self._reference, metric="time_span_accuracy"
+        )
+        self.assertAlmostEqual(accuracy, 1.6 / 3, places=3)
+        precision = calculate_time_span_accuracy(
+            hypothesis=hypothesis, reference=self._reference, metric="time_span_precision"
+        )
+        self.assertAlmostEqual(precision, 1.1 / 1.6, places=3)
+        recall = calculate_time_span_accuracy(
+            hypothesis=hypothesis, reference=self._reference, metric="time_span_recall"
+        )
+        self.assertAlmostEqual(recall, 1.1 / 2, places=3)
+        f1 = calculate_time_span_accuracy(hypothesis=hypothesis, reference=self._reference, metric="time_span_f1")
+        self.assertAlmostEqual(f1, 2 * precision * recall / (precision + recall), places=3)


### PR DESCRIPTION
Adds metrics "time_span_accuracy", "time_span_precision", "time_span_recall" and "time_span_f1" via pyannote, see detection metrics in https://pyannote.github.io/pyannote-metrics/reference.html
This library seems to be widely used in voice activity detection and speaker diarization. (But it adds a bit many dependencies for my taste. 🙃 Could be made optional maybe.) 

Naming of the metrics could maybe be improved? I avoided "coverage" because there is segmentation metric in pyannote with that name.

But these metrics evaluate how much of reference subtitles duration is "covered". For example, recall is the total duration where both hypothesis and reference have a subtitle, divided by the total duration of reference subtitles.

pyannote also has segmentation recall/precision, which - applied to subtitling - would evaluate how many subtitles start/end at the same time in hypothesis and reference, within a certain tolerance interval. That could also be interesting!

I get these numbers for some file I had lying around:
```
{
    "time_span_accuracy": 0.842,
    "time_span_precision": 0.858,
    "time_span_recall": 0.821,
    "time_span_f1": 0.839
}
```
If I take a completely different/wrong SRT file as reference I get:
```
{
    "time_span_accuracy": 0.511,
    "time_span_precision": 0.451,
    "time_span_recall": 0.485,
    "time_span_f1": 0.467
}
```
So very first impression is that those metrics could indeed be useful.