### PR TITLE
Add BLEURT metric

### DIFF
--- a/suber/__main__.py
+++ b/suber/__main__.py
@@ -12,6 +12,7 @@ from suber.hyp_to_ref_alignment import time_align_hypothesis_to_reference
 from suber.metrics.suber import calculate_SubER
 from suber.metrics.suber_statistics import SubERStatisticsCollector
 from suber.metrics.sacrebleu_interface import calculate_sacrebleu_metric
+from suber.metrics.bleurt_interface import calculate_bleurt
 from suber.metrics.jiwer_interface import calculate_word_error_rate
 from suber.metrics.cer import calculate_character_error_rate
 from suber.metrics.length_ratio import calculate_length_ratio
@@ -44,6 +45,8 @@ def parse_arguments():
     parser.add_argument("--suber-statistics", action="store_true",
                         help="If set, will create an '#info' field in the output containing statistics about the "
                              "different edit operations used to calculate the SubER score.")
+    parser.add_argument("--bleurt-checkpoint",
+                        help="BLEURT model checkpoint folder, required if (AS-)BLEURT used as one of the metrics.")
 
     return parser.parse_args()
 
@@ -134,6 +137,10 @@ def main():
             metric_score = calculate_character_error_rate(
                 hypothesis=hypothesis_segments_to_use, reference=reference_segments, metric=metric)
 
+        elif metric == "BLEURT":
+            metric_score = calculate_bleurt(
+                hypothesis=hypothesis_segments_to_use, reference=reference_segments, checkpoint=args.bleurt_checkpoint)
+
         else:
             metric_score = calculate_sacrebleu_metric(
                 hypothesis=hypothesis_segments_to_use, reference=reference_segments, metric=metric,
@@ -153,7 +160,7 @@ def check_metrics(metrics):
         # Our proposed metric:
         "SubER", "SubER-cased",
         # Established ASR and MT metrics, requiring aligned hypothesis-references segments:
-        "WER", "CER", "BLEU", "TER", "chrF",
+        "WER", "CER", "BLEU", "TER", "chrF", "BLEURT",
         # Cased and punctuated variants of the above:
         "WER-cased", "CER-cased",
         # Segmentation-aware variants of the above that include line breaks as tokens:
@@ -162,7 +169,7 @@ def check_metrics(metrics):
         # proposed by Karakanta et al. https://aclanthology.org/2020.iwslt-1.26.pdf
         "TER-br",
         # With an "AS-" prefix, the metric is computed after Levenshtein alignment of hypothesis and reference:
-        "AS-WER", "AS-CER", "AS-BLEU", "AS-TER", "AS-chrF", "AS-WER-cased", "AS-CER-cased", "AS-WER-seg",
+        "AS-WER", "AS-CER", "AS-BLEU", "AS-TER", "AS-chrF", "AS-BLEURT", "AS-WER-cased", "AS-CER-cased", "AS-WER-seg",
         "AS-BLEU-seg", "AS-TER-seg", "AS-TER-br",
         # With an "t-" prefix, the metric is computed after time alignment of hypothesis and reference:
         "t-WER", "t-CER", "t-BLEU", "t-TER", "t-chrF", "t-WER-cased", "t-CER-cased", "t-WER-seg", "t-BLEU-seg",

--- a/suber/metrics/bleurt_interface.py
+++ b/suber/metrics/bleurt_interface.py
@@ -1,0 +1,26 @@
+from typing import List
+
+from suber.data_types import Segment
+from suber.utilities import segment_to_string
+
+
+def calculate_bleurt(hypothesis: List[Segment], reference: List[Segment], checkpoint=None) -> float:
+
+    from bleurt import score  # Local import to make dependency optional.
+
+    if not checkpoint:
+        raise ValueError(
+            "BLEURT checkpoint needs to be downloaded and specified via --bleurt-checkpoint. "
+            "See https://github.com/google-research/bleurt/blob/master/README.md")
+
+    score.logging.set_verbosity("INFO")
+
+    hypothesis_strings = [segment_to_string(segment) for segment in hypothesis]
+    reference_strings = [segment_to_string(segment) for segment in reference]
+
+    scorer = score.BleurtScorer(checkpoint)
+    scores = scorer.score(references=reference_strings, candidates=hypothesis_strings)
+
+    average_score = sum(scores) / len(scores)
+
+    return round(average_score, 3)


### PR DESCRIPTION
BLEURT is used as a metric at the IWSLT subtitling track. This is *not* the code used for evaluation there, but it probably makes sense to add this implementation here for convenience. Scores should be similar to the official ones if one uses `--metrics AS-BLEURT` and a reference in SRT format. This will Levenshtein-align the hypothesis words into the reference subtitle blocks and then compute and average BLEURT scores over the aligned pairs. For IWSLT, [mwerSegmenter](https://www-i6.informatik.rwth-aachen.de/web/Software/mwerSegmenter.tar.gz) is used instead, resulting in slightly different alignment compared to our Levenshtein implementation.
To me it is still an open question whether calculating learned metrics on such automatically aligned segments is really sound, because in many cases starts and ends of sentences are chopped off. For surface-level metrics that does not matter much, but learned metrics are trained on proper complete sentences. And indeed [recent work](https://aclanthology.org/2025.iwslt-1.7.pdf) by Post and Hoang shows that - in this case - COMET scores degrade with automatic segmentation, although system ranking seems to be preserved overall.
I would also intuitively expect that full sentences as reference segments rather than subtitle blocks should give more accurate scores. (Can be done by passing a plain text reference, see README.) But as of now I did not evaluate that systematically.
So, even if we merge this, the BLEURT metric might be subject to changes/improvements - as opposed to the other metrics which I want to be very stable.

Note, that many other learned metrics like COMET require a source input and are therefore not trivial to compute for subtitling, or speech translation in general.
